### PR TITLE
Replace MathJax CDN

### DIFF
--- a/categories.html
+++ b/categories.html
@@ -1071,7 +1071,7 @@ depth = cata phi where
 	});
 </script>
 <!-- Y theme -->
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script src="js/highlight/highlight.pack.js"></script>
 <script>
     hljs.initHighlightingOnLoad();

--- a/index.html
+++ b/index.html
@@ -1071,7 +1071,7 @@ depth = cata phi where
 	});
 </script>
 <!-- Y theme -->
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script src="js/highlight/highlight.pack.js"></script>
 <script>
     hljs.initHighlightingOnLoad();


### PR DESCRIPTION
Awesome presentation, thank you for making it!

I've updated the CDN URL used as it's shutting down. (see [here](https://www.mathjax.org/cdn-shutting-down/)).
Also the current URL does not support visiting the site with https.

This closes https://github.com/yogsototh/Category-Theory-Presentation/issues/2